### PR TITLE
User Views

### DIFF
--- a/ace/urls.py
+++ b/ace/urls.py
@@ -2,10 +2,11 @@ from django.contrib import admin
 from django.urls import path
 from django.conf.urls import include
 from rest_framework import routers
-from aceapi.views import (register_user, login_user, DayView)
+from aceapi.views import (register_user, login_user, DayView, AppUserView)
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'days', DayView, 'day')
+router.register(r'users', AppUserView, 'user')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/aceapi/fixtures/appusers.json
+++ b/aceapi/fixtures/appusers.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "aceapi.appuser",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "bio": "Tutoring for 10 years. Specializing in ACT/SAT, ISEE, biology, and lower math",
+            "billing_rate": 115
+        }
+    },
+    {
+        "model": "aceapi.appuser",
+        "pk": 2,
+        "fields": {
+            "user": 2,
+            "bio": "Junior at Harpeth Hall. Gets testing anxiety",
+            "day": 1,
+            "start_time": "11:00:00",
+            "end_time": "12:00:00",
+            "parent_name": "Kelly Lynd",
+            "parent_email": "kelly@lynd.com"
+        }
+    },
+    {
+        "model": "aceapi.appuser",
+        "pk": 3,
+        "fields": {
+            "user": 3,
+            "bio": "Junior at Father Ryan. Plays volleyball, wants to continue in college",
+            "day": 1,
+            "start_time": "16:30:00",
+            "end_time": "17:30:00",
+            "parent_name": "Arlie Paris",
+            "parent_email": "arlie@paris.com"
+        }
+    }
+]

--- a/aceapi/fixtures/likes.json
+++ b/aceapi/fixtures/likes.json
@@ -12,7 +12,7 @@
         "pk": 2,
         "fields": {
             "tutor": 1,
-            "test": 1
+            "test": 2
         }
     }
 ]

--- a/aceapi/fixtures/likes.json
+++ b/aceapi/fixtures/likes.json
@@ -1,0 +1,18 @@
+[
+    {
+        "model": "aceapi.like",
+        "pk": 1,
+        "fields": {
+            "tutor": 1,
+            "test": 1
+        }
+    },
+    {
+        "model": "aceapi.like",
+        "pk": 2,
+        "fields": {
+            "tutor": 1,
+            "test": 1
+        }
+    }
+]

--- a/aceapi/fixtures/notes.json
+++ b/aceapi/fixtures/notes.json
@@ -1,0 +1,46 @@
+[
+    {
+        "model": "aceapi.note",
+        "pk": 1,
+        "fields": {
+            "student": 2,
+            "author": 2,
+            "note": "I'll be out of town on the 13th for spring break",
+            "date": "2022-03-06",
+            "pinned": false
+        }
+    },
+    {
+        "model": "aceapi.note",
+        "pk": 2,
+        "fields": {
+            "student": 2,
+            "author": 1,
+            "note": "Finished functions problems in Misc packet. HW: Misc packet #28-35",
+            "date": "2022-03-06",
+            "pinned": false
+        }
+    },
+    {
+        "model": "aceapi.note",
+        "pk": 3,
+        "fields": {
+            "student": 2,
+            "author": 1,
+            "note": "Need to work on timing for Reading section especially",
+            "date": "2022-01-09",
+            "pinned": true
+        }
+    },
+    {
+        "model": "aceapi.note",
+        "pk": 4,
+        "fields": {
+            "student": 3,
+            "author": 1,
+            "note": "More comfortable with topic sentence reading",
+            "date": "2022-02-20",
+            "pinned": false
+        }
+    }
+]

--- a/aceapi/fixtures/scores.json
+++ b/aceapi/fixtures/scores.json
@@ -1,0 +1,41 @@
+[
+    {
+        "model": "aceapi.score",
+        "pk": 1,
+        "fields": {
+            "student": 2,
+            "test": 3,
+            "date": "2022-01-1",
+            "english": 19,
+            "math": 24,
+            "reading": 25,
+            "science": 21
+        }
+    },
+    {
+        "model": "aceapi.score",
+        "pk": 2,
+        "fields": {
+            "student": 2,
+            "test": 4,
+            "date": "2022-02-27",
+            "english": 22,
+            "math": 24,
+            "reading": 26,
+            "science": 23
+        }
+    },
+    {
+        "model": "aceapi.score",
+        "pk": 3,
+        "fields": {
+            "student": 3,
+            "test": 3,
+            "date": "2022-02-26",
+            "english": 18,
+            "math": 16,
+            "reading": 17,
+            "science": 16
+        }
+    }
+]

--- a/aceapi/fixtures/student_subject_areas.json
+++ b/aceapi/fixtures/student_subject_areas.json
@@ -1,0 +1,74 @@
+[
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 1,
+        "fields": {
+            "student": 2,
+            "subject_area": 4
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 2,
+        "fields": {
+            "student": 2,
+            "subject_area": 5
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 3,
+        "fields": {
+            "student": 2,
+            "subject_area": 6
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 4,
+        "fields": {
+            "student": 2,
+            "subject_area": 12
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 5,
+        "fields": {
+            "student": 2,
+            "subject_area": 15
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 6,
+        "fields": {
+            "student": 3,
+            "subject_area": 3
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 7,
+        "fields": {
+            "student": 3,
+            "subject_area": 9
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 8,
+        "fields": {
+            "student": 3,
+            "subject_area": 6
+        }
+    },
+    {
+        "model": "aceapi.studentsubjectarea",
+        "pk": 9,
+        "fields": {
+            "student": 3,
+            "subject_area": 10
+        }
+    }
+]

--- a/aceapi/fixtures/student_tests.json
+++ b/aceapi/fixtures/student_tests.json
@@ -1,0 +1,62 @@
+[
+    {
+        "model": "aceapi.studenttest",
+        "pk": 1,
+        "fields": {
+            "student": 2,
+            "test": 1,
+            "english": "1,1,1,0,0,0",
+            "math": "1,1,1",
+            "reading": "1,1,1,1",
+            "science": "1,1,1,1,0,0,0"
+        }
+    },
+    {
+        "model": "aceapi.studenttest",
+        "pk": 2,
+        "fields": {
+            "student": 2,
+            "test": 2,
+            "english": "1,1,1,0,0,0",
+            "math": "0,1,0",
+            "reading": "1,1,1,1",
+            "science": "0,0,0,0,0,0"
+        }
+    },
+    {
+        "model": "aceapi.studenttest",
+        "pk": 3,
+        "fields": {
+            "student": 2,
+            "test": 3,
+            "english": "1,1,1,0,0,0",
+            "math": "0,1,1",
+            "reading": "0,1,1,0",
+            "science": "0,1,1,0,0,1"
+        }
+    },
+    {
+        "model": "aceapi.studenttest",
+        "pk": 4,
+        "fields": {
+            "student": 2,
+            "test": 4,
+            "english": "1,0,0,0,0,0",
+            "math": "0,1,0",
+            "reading": "0,0,1,1",
+            "science": "0,0,0,1,1,0"
+        }
+    },
+    {
+        "model": "aceapi.studenttest",
+        "pk": 5,
+        "fields": {
+            "student": 3,
+            "test": 1,
+            "english": "1,1,1,0,0,0",
+            "math": "0,1,0",
+            "reading": "1,1,1,1",
+            "science": "0,0,0,0,0,0"
+        }
+    }
+]

--- a/aceapi/fixtures/subject_areas.json
+++ b/aceapi/fixtures/subject_areas.json
@@ -1,0 +1,122 @@
+[
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 1,
+        "fields": {
+            "subject_id": 1,
+            "name": "Production of Knowledge"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 2,
+        "fields": {
+            "subject_id": 1,
+            "name": "Language"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 3,
+        "fields": {
+            "subject_id": 1,
+            "name": "English Conventions"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 4,
+        "fields": {
+            "subject_id": 2,
+            "name": "Algebra"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 5,
+        "fields": {
+            "subject_id": 2,
+            "name": "Functions"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 6,
+        "fields": {
+            "subject_id": 2,
+            "name": "Geometry"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 7,
+        "fields": {
+            "subject_id": 2,
+            "name": "Statistics & Probability"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 8,
+        "fields": {
+            "subject_id": 2,
+            "name": "Integrating Skills"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 9,
+        "fields": {
+            "subject_id": 2,
+            "name": "Modeling"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 10,
+        "fields": {
+            "subject_id": 3,
+            "name": "Key Ideas and Details"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 11,
+        "fields": {
+            "subject_id": 3,
+            "name": "Craft and Structure"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 12,
+        "fields": {
+            "subject_id": 3,
+            "name": "Integrate KNowledge and Ideas"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 13,
+        "fields": {
+            "subject_id": 4,
+            "name": "Interpret Data"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 14,
+        "fields": {
+            "subject_id": 4,
+            "name": "Scientific Investigation"
+        }
+    },
+    {
+        "model": "aceapi.subjectarea",
+        "pk": 15,
+        "fields": {
+            "subject_id": 4,
+            "name": "Evaluation of Models, Inferences, and Results"
+        }
+    }
+]

--- a/aceapi/fixtures/subjects.json
+++ b/aceapi/fixtures/subjects.json
@@ -1,0 +1,30 @@
+[
+    {
+        "model": "aceapi.subject",
+        "pk": 1,
+        "fields": {
+            "subject": "English"
+        }
+    },
+    {
+        "model": "aceapi.subject",
+        "pk": 2,
+        "fields": {
+            "subject": "Math"
+        }
+    },
+    {
+        "model": "aceapi.subject",
+        "pk": 3,
+        "fields": {
+            "subject": "Reading"
+        }
+    },
+    {
+        "model": "aceapi.subject",
+        "pk": 4,
+        "fields": {
+            "subject": "Science"
+        }
+    }
+]

--- a/aceapi/fixtures/tests.json
+++ b/aceapi/fixtures/tests.json
@@ -1,0 +1,38 @@
+[
+    {
+        "model": "aceapi.test",
+        "pk": 1,
+        "fields": {
+            "name": "68C",
+            "year": 2010,
+            "num_sci": 7
+        }
+    },
+    {
+        "model": "aceapi.test",
+        "pk": 2,
+        "fields": {
+            "name": "72F",
+            "year": 2016,
+            "num_sci": 6
+        }
+    },
+    {
+        "model": "aceapi.test",
+        "pk": 3,
+        "fields": {
+            "name": "B04",
+            "year": 2019,
+            "num_sci": 6
+        }
+    },
+    {
+        "model": "aceapi.test",
+        "pk": 4,
+        "fields": {
+            "name": "A11",
+            "year": 2018,
+            "num_sci": 6
+        }
+    }
+]

--- a/aceapi/fixtures/tokens.json
+++ b/aceapi/fixtures/tokens.json
@@ -1,0 +1,26 @@
+[
+    {
+        "model": "authtoken.token",
+        "pk": "5a5af569c2d96781028365fdfb6230276eaffebd",
+        "fields": {
+            "user": 1,
+            "created": "2020-08-29T13:24:27.172Z"
+        }
+    },
+    {
+        "model": "authtoken.token",
+        "pk": "6b5af569c2d96781028365fdfb6230276eaffebd",
+        "fields": {
+            "user": 2,
+            "created": "2020-08-29T13:24:27.172Z"
+        }
+    },
+    {
+        "model": "authtoken.token",
+        "pk": "7c5af569c2d96781028365fdfb6230276eaffebd",
+        "fields": {
+            "user": 3,
+            "created": "2020-08-29T13:24:27.172Z"
+        }
+    }
+]

--- a/aceapi/fixtures/tutor_students.json
+++ b/aceapi/fixtures/tutor_students.json
@@ -1,0 +1,18 @@
+[
+    {
+        "model": "aceapi.tutorstudent",
+        "pk": 1,
+        "fields": {
+            "tutor": 1,
+            "student": 2
+        }
+    },
+    {
+        "model": "aceapi.tutorstudent",
+        "pk": 2,
+        "fields": {
+            "tutor": 1,
+            "student": 3
+        }
+    }
+]

--- a/aceapi/fixtures/users.json
+++ b/aceapi/fixtures/users.json
@@ -1,0 +1,56 @@
+[
+    {
+        "model": "auth.user",
+        "pk": 1,
+        "fields": {
+            "password": "pbkdf2_sha256$320000$gcFbjpBpJbFBz6zo7YG9hM$Qy3aGFjOOuWNhktMdnHhPmEJsQgIWfoy55CDmJo6Pzg=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "melissa",
+            "first_name": "Melissa",
+            "last_name": "Fox",
+            "email": "melissa@fox.com",
+            "is_staff": true,
+            "is_active": true,
+            "date_joined": "2020-08-28T14:51:39.989Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "auth.user",
+        "pk": 2,
+        "fields": {
+            "password": "pbkdf2_sha256$320000$L9LWX8YcqcYia86EIwxWtL$tyN52cc+QwvyXnrWOn04KbeR1TGrLd80CRg5RlZNfog=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "morgan",
+            "first_name": "Morgan",
+            "last_name": "Lynd",
+            "email": "morgan@lynd.com",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2020-08-28T14:51:39.989Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "auth.user",
+        "pk": 3,
+        "fields": {
+            "password": "pbkdf2_sha256$320000$s8uapJ6dpP7exeqbrNWdln$EtDLtM7WxoN2aRmCE7g4+7H/RDherzWyq9fRx/Z1jro=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "kyra",
+            "first_name": "Kyra",
+            "last_name": "Paris",
+            "email": "kyra@paris.com",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2020-08-28T14:51:39.989Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    }
+]

--- a/aceapi/models/student_test.py
+++ b/aceapi/models/student_test.py
@@ -4,7 +4,7 @@ from aceapi.models import AppUser, Test
 class StudentTest(models.Model):
     student = models.ForeignKey(AppUser, on_delete=models.CASCADE)
     test = models.ForeignKey(Test, on_delete=models.CASCADE)
-    english = []
-    math = []
-    reading = []
-    science = []
+    english = models.CharField(max_length=20)
+    math = models.CharField(max_length=20)
+    reading = models.CharField(max_length=20)
+    science = models.CharField(max_length=20)

--- a/aceapi/views/__init__.py
+++ b/aceapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .day import DayView
 from .auth import login_user, register_user
+from .user import AppUserView

--- a/aceapi/views/day.py
+++ b/aceapi/views/day.py
@@ -24,8 +24,8 @@ class DayView(ViewSet):
             Response: JSON serialized day instance
         """
         try:
-            food_type=Day.objects.get(pk=pk)
-            serializer = DaySerializer(food_type)
+            day=Day.objects.get(pk=pk)
+            serializer = DaySerializer(day)
             return Response(serializer.data)
         except Day.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/aceapi/views/user.py
+++ b/aceapi/views/user.py
@@ -25,6 +25,26 @@ class AppUserView(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
 
+    def update(self, request, pk):
+        """update app_user"""
+        try:
+            user = AppUser.objects.get(pk=pk)
+            user.bio = request.data['bio']
+            if user.user.is_staff:
+                user.billing_rate = request.data['billingRate']
+            else:
+                user.day_id = request.data['dayId']
+                user.start_time = request.data['startTime']
+                user.end_time = request.data['endTime']
+                user.parent_name = request.data['parentName']
+                user.parent_email = request.data['parentEmail']
+            user.save()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        except AppUser.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+
     @action(methods=['get'], detail=False)
     def current(self,request):
         """get current user"""

--- a/aceapi/views/user.py
+++ b/aceapi/views/user.py
@@ -1,0 +1,100 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rest_framework.decorators import action
+from django.contrib.auth.models import User
+from aceapi.models import AppUser
+
+class AppUserView(ViewSet):
+
+    def retrieve(self, request, pk=None):
+        """Handle GET request for a single app_user
+
+        Returns:
+            Response: JSON serialized user instance
+        """
+        try:
+            app_user=AppUser.objects.get(pk=pk)
+            if app_user.user.is_staff:
+                serializer = TutorSerializer(app_user)
+                return Response(serializer.data, status=status.HTTP_200_OK)
+            else:
+                serializer = StudentSerializer(app_user)
+                return Response(serializer.data, status=status.HTTP_200_OK)
+        except AppUser.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+
+    @action(methods=['get'], detail=False)
+    def current(self,request):
+        """get current user"""
+        user = AppUser.objects.get(user = request.auth.user)
+        if user.user.is_staff:
+            serializer = TutorSerializer(user)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            serializer = StudentSerializer(user)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+    @action(methods=['get'], detail=False)
+    def students(self,request):
+        """get list of student users"""
+        students = AppUser.objects.filter(user__is_staff = False)
+        serializer = StudentSerializer(students, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+    @action(methods=['get'], detail=False)
+    def tutors(self,request):
+        """get list of tutor users"""
+        tutors = AppUser.objects.filter(user__is_staff = True)
+        serializer = TutorSerializer(tutors, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+    @action(methods=['put'], detail=True)
+    def activate(self,request, pk):
+        """activate user"""
+        try:
+            user = User.objects.get(pk=pk)
+            user.is_active = 1
+            user.save()
+            return Response({'message: user is now active'}, status=status.HTTP_204_NO_CONTENT)
+        except User.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+
+    @action(methods=['put'], detail=True)
+    def deactivate(self,request, pk):
+        """activate user"""
+        try:
+            user = User.objects.get(pk=pk)
+            user.is_active = 0
+            user.save()
+            return Response({'message: user has been deactivated'},
+                            status=status.HTTP_204_NO_CONTENT)
+        except User.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'is_superuser', 'username', 'first_name', 'last_name',
+                  'email', 'is_staff', 'is_active')
+
+class StudentSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+    class Meta:
+        model = AppUser
+        fields = ('id', 'user', 'bio', 'day',
+                  'start_time', 'end_time', 'parent_name', 'parent_email' )
+        depth = 1
+
+class TutorSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+    class Meta:
+        model = AppUser
+        fields = ('id', 'user', 'bio', 'billing_rate')
+        depth = 1


### PR DESCRIPTION
Description of Changes:
- completed fixtures for all models
- retrieve view uses either Tutor Serializer or Student Serializer depending on the returned AppUser (checks is_staff)
- update view checks for is_staff property and only updates the tutor/student specific fields
- custom actions for returning current user, list of students, list of tutors, and activating/deactivating users

Does this request support or fix an existing issue?
Fixes #3 
Fixes #5 